### PR TITLE
chore: release v2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@synapsestudios/eslint-plugin-data-boundaries",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@synapsestudios/eslint-plugin-data-boundaries",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@mrleebo/prisma-ast": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synapsestudios/eslint-plugin-data-boundaries",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "ESLint plugin to enforce data boundary policies in modular monoliths",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bumps version from 2.0.0 → 2.0.1
- Release rolls up security fixes from #21 (chevrotain v12 override, drops vulnerable lodash-es) and #22 (js-yaml 3.14.2 for prototype pollution)

## Release plan
After merge:
1. Tag the merge commit as `v2.0.1`
2. Push the tag
3. `npm publish --access public`

## Test plan
- [x] `npm test` — 90 tests pass
- [x] `npm audit` — 0 vulnerabilities
- [x] `npm run lint` — no errors
- [x] `npm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)