### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
+    assignees:
+      - "spruce-bruce"
+    reviewers:
+      - "spruce-bruce"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    assignees:
+      - "spruce-bruce"
+    reviewers:
+      - "spruce-bruce"


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with daily update schedules for `npm` and `github-actions`.
- Assigns and requests review from @spruce-bruce on all Dependabot PRs.
- npm ecosystem capped at 10 open PRs.

## Test plan
- [ ] Merge to main and confirm Dependabot picks up the config (check Insights → Dependency graph → Dependabot).
- [ ] Verify next opened Dependabot PR is auto-assigned to @spruce-bruce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)