### PR TITLE
chore(deps-dev): bump typescript to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "prettier": "^3.6.2",
         "slonik": "^48.14.1",
         "ts-jest": "^29.4.0",
-        "typescript": "^5.8.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=18.18.0"
@@ -6132,9 +6132,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "prettier": "^3.6.2",
     "slonik": "^48.14.1",
     "ts-jest": "^29.4.0",
-    "typescript": "^5.8.3"
+    "typescript": "^6.0.3"
   },
   "engines": {
     "node": ">=18.18.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,9 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "moduleResolution": "node",
-    "resolveJsonModule": true
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "types": ["node"]
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
## Summary
- Bumps `typescript` from 5.8.3 to 6.0.3 (supersedes #33).
- Migrates `tsconfig.json` `moduleResolution` from the now-deprecated `node` (alias of `node10`) to `bundler`, which is non-deprecated in TS 6 and preserves the loose CJS import semantics this plugin relies on.
- Adds explicit `types: ["node"]` since `bundler` resolution does not auto-include `@types/node` in this setup.

## Test plan
- [x] `npm run build` — clean
- [x] `npm run lint` — no new errors (existing warnings unchanged)
- [x] `npm run format:check` — clean
- [x] `npm test` — 90/90 passing
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)