### PR TITLE
chore: release v2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@synapsestudios/eslint-plugin-data-boundaries",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@synapsestudios/eslint-plugin-data-boundaries",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "@mrleebo/prisma-ast": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synapsestudios/eslint-plugin-data-boundaries",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "ESLint plugin to enforce data boundary policies in modular monoliths",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- Bumps package version to 2.0.2.
- Picks up the `@mrleebo/prisma-ast` 0.14 → 0.16 bump (#42), which transitively upgrades `chevrotain` from 11.2.0 to 12.0.0 and drops the vulnerable `lodash-es@4.17.23` from the dependency tree.
- Also rolls in everything else merged since v2.0.1 (TypeScript 6, typescript-eslint 8.59.3, glob 13, jest 30.4.2, ts-jest 29.4.11, slonik 48.14.4, Dependabot config).

## Test plan
- [ ] CI green
- [ ] After merge: tag `v2.0.2` on main, push tag, `npm publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)