### PR TITLE
chore: add publishConfig.access=public

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "README.md",
     "LICENSE"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",


### PR DESCRIPTION
## Summary
- Adds `publishConfig.access = "public"` to `package.json` so `npm publish` works without `--access public` on the CLI.
- Scoped packages (`@synapsestudios/...`) default to private on npm, so without this every publish requires remembering the flag.

## Test plan
- [ ] CI green
- [ ] Next `npm publish` from main succeeds without `--access public`

🤖 Generated with [Claude Code](https://claude.com/claude-code)