### PR TITLE
chore(deps): bump brace-expansion to 5.0.6 in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4828,9 +4828,9 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"


### PR DESCRIPTION
## Summary
- Bumps transitive `brace-expansion` from 5.0.5 → 5.0.6 in `package-lock.json` to resolve [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) (ReDoS via large numeric ranges).
- Reached via `eslint → minimatch@10 → brace-expansion@5.0.5`.
- Lockfile-only change. `brace-expansion` is only reachable through devDependencies, so this does not affect what consumers of the published package install — it just clears `npm audit` on our repo.

## Test plan
- [x] `npm audit` reports 0 vulnerabilities locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)