### PR TITLE
chore: tune dependabot — request review + 5-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 5
     reviewers:
       - "spruce-bruce"
 
@@ -12,5 +14,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
     reviewers:
       - "spruce-bruce"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-    assignees:
-      - "spruce-bruce"
     reviewers:
       - "spruce-bruce"
 
@@ -14,7 +12,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    assignees:
-      - "spruce-bruce"
     reviewers:
       - "spruce-bruce"


### PR DESCRIPTION
## Summary
Two related Dependabot config tweaks:

1. **Drop `assignees`, keep `reviewers`** so Dependabot PRs land as review requests. GitHub's Slack app DMs on review requests, not assignments — combining both also seems to suppress the review request (every recent Dependabot PR shipped with `requested_reviewers: []` despite the config).

2. **Add `cooldown: default-days: 5`** so Dependabot skips proposing a bump until a version has been published for 5 days. Avoids opening PRs for brand-new releases that haven't had time to be vetted or yanked if compromised.

## Caveat (on the reviewer change)
The `reviewers:` field has known reliability issues for individual users. If the next Dependabot PR still lands without a review request, fallback is a `.github/CODEOWNERS` file with `* @spruce-bruce`, which auto-requests review on every PR.

## Test plan
- [ ] CI green
- [ ] After merge: wait for the next Dependabot PR — confirm review is requested on `spruce-bruce` and bumps are for versions ≥5 days old

🤖 Generated with [Claude Code](https://claude.com/claude-code)