### PR TITLE
chore: link to release PR from workflow summary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base main \
             --head "release/${{ steps.bump.outputs.version }}" \
             --title "chore(release): ${{ steps.bump.outputs.version }}" \
-            --body "Automated release PR. Merging triggers publish to npm."
+            --body "Automated release PR. Merging triggers publish to npm.")
+          echo "Opened: $PR_URL"
+          {
+            echo "### Release PR opened for ${{ steps.bump.outputs.version }}"
+            echo ""
+            echo "[$PR_URL]($PR_URL)"
+            echo ""
+            echo "Merge to publish to npm."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

When the **Release** workflow runs, it now writes a clickable link to the release PR into the workflow run summary so you can jump straight to the PR from the Actions UI.

## Test plan

- [ ] After merge, run **Release** with `patch` and verify the run's summary page shows the PR URL as a clickable link.